### PR TITLE
Bump to latest version of nightfall_code_scanner

### DIFF
--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -1,22 +1,24 @@
 {
-  "conditions": [
+  "detectionRules": [
     {
-      "detector": {
-        "detectorType": "NIGHTFALL_DETECTOR",
-        "nightfallDetector": "API_KEY",
-        "displayName": "api key"
-      },
-      "minNumFindings": 1,
-      "minConfidence": "LIKELY"
-    },
-    {
-      "detector": {
-        "detectorType": "NIGHTFALL_DETECTOR",
-        "nightfallDetector": "CRYPTOGRAPHIC_KEY",
-        "displayName": "crypto key"
-      },
-      "minNumFindings": 1,
-      "minConfidence": "LIKELY"
+      "name": "",
+      "detectors": [
+        {
+          "minNumFindings": 1,
+          "minConfidence": "LIKELY",
+          "displayName": "api key",
+          "detectorType": "NIGHTFALL_DETECTOR",
+          "nightfallDetector": "API_KEY"
+        },
+        {
+          "minNumFindings": 1,
+          "minConfidence": "LIKELY",
+          "displayName": "crypto key",
+          "detectorType": "NIGHTFALL_DETECTOR",
+          "nightfallDetector": "CRYPTOGRAPHIC_KEY"
+        }
+      ],
+      "logicalOp": "ANY"
     }
   ],
   "maxNumberConcurrentRoutines": 5,
@@ -26,5 +28,12 @@
     "301-123-4567",
     "1-240-925-5721",
     "xG0Ct4Wsu3OTcJnE1dFLAQfRgL6b8tIv"
-  ]
+  ],
+  "defaultRedactionConfig": {
+    "maskConfig": {
+      "maskingChar": "*",
+      "numCharsToLeaveUnmasked": 2
+    }
+  }
 }
+

--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -5,7 +5,7 @@
       "detectors": [
         {
           "minNumFindings": 1,
-          "minConfidence": "LIKELY",
+          "minConfidence": "VERY_UNLIKELY",
           "displayName": "api key",
           "detectorType": "NIGHTFALL_DETECTOR",
           "nightfallDetector": "API_KEY"

--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -5,7 +5,7 @@
       "detectors": [
         {
           "minNumFindings": 1,
-          "minConfidence": "VERY_UNLIKELY",
+          "minConfidence": "LIKELY",
           "displayName": "api key",
           "detectorType": "NIGHTFALL_DETECTOR",
           "nightfallDetector": "API_KEY"
@@ -38,7 +38,10 @@
     "xG0Ct4Wsu3OTcJnE1dFLAQfRgL6b8tIv"
   ],
   "defaultRedactionConfig": {
-    "infoTypeSubstitutionConfig": {}
+    "maskConfig": {
+      "maskingChar": "*",
+      "numCharsToLeaveUnmasked": 2
+    }
   }
 }
 

--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -29,7 +29,7 @@
     }
   ],
   "maxNumberConcurrentRoutines": 5,
-  "fileExclusionList": ["./README.md"]
+  "fileExclusionList": ["./README.md"],
   "tokenExclusionList": [
     "4916-6734-7572-5015",
     "4242-4242-4242-4242",

--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -38,10 +38,7 @@
     "xG0Ct4Wsu3OTcJnE1dFLAQfRgL6b8tIv"
   ],
   "defaultRedactionConfig": {
-    "maskConfig": {
-      "maskingChar": "*",
-      "numCharsToLeaveUnmasked": 2
-    }
+    "infoTypeSubstitutionConfig": {}
   }
 }
 

--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -29,7 +29,7 @@
     }
   ],
   "maxNumberConcurrentRoutines": 5,
-  "fileExclusionList": ["./README.md"],
+  "fileExclusionList": ["README.md"],
   "tokenExclusionList": [
     "4916-6734-7572-5015",
     "4242-4242-4242-4242",

--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -29,6 +29,7 @@
     }
   ],
   "maxNumberConcurrentRoutines": 5,
+  "fileExclusionList": ["./README.md"]
   "tokenExclusionList": [
     "4916-6734-7572-5015",
     "4242-4242-4242-4242",

--- a/.nightfalldlp/config.json
+++ b/.nightfalldlp/config.json
@@ -16,6 +16,13 @@
           "displayName": "crypto key",
           "detectorType": "NIGHTFALL_DETECTOR",
           "nightfallDetector": "CRYPTOGRAPHIC_KEY"
+        },
+        {
+          "minNumFindings": 1,
+          "minConfidence": "LIKELY",
+          "displayName": "password",
+          "detectorType": "NIGHTFALL_DETECTOR",
+          "nightfallDetector": "PASSWORD_IN_CODE"
         }
       ],
       "logicalOp": "ANY"

--- a/orb.yml
+++ b/orb.yml
@@ -9,7 +9,7 @@ jobs:
         description: |
             Scan Pull Requests and Commits for sensitive findings. You must set the NIGHTFALL_API_KEY as a CircleCI project environment variable to use this orb. View this orb's source and README for usage instructions.
         docker:
-            - image: nightfallai/nightfall_code_scanner:v1.1.4
+            - image: nightfallai/nightfall_code_scanner:v2.0.0
         parameters:
             base_branch:
                 default: ""
@@ -40,7 +40,7 @@ examples:
         usage:
             version: 2.1
             orbs:
-                nightfall_code_scanner: nightfall/nightfall_code_scanner@2.0.3
+                nightfall_code_scanner: nightfall/nightfall_code_scanner@2.0.0
             workflows:
                 build:
                     jobs:

--- a/sample-trigger.txt
+++ b/sample-trigger.txt
@@ -1,1 +1,0 @@
-my nightfall API key is NF-p3VPiS3LZBeoGbzDeK9G33WNTXYRFHu7

--- a/sample-trigger.txt
+++ b/sample-trigger.txt
@@ -1,0 +1,1 @@
+my nightfall API key is NF-p3VPiS3LZBeoGbzDeK9G33WNTXYRFHu7

--- a/src/examples/scan_findings.yml
+++ b/src/examples/scan_findings.yml
@@ -2,7 +2,7 @@ description: Scan diff for potential sensitive items.
 usage:
   version: 2.1
   orbs:
-    nightfall_code_scanner: nightfall/nightfall_code_scanner@1.1.4
+    nightfall_code_scanner: nightfall/nightfall_code_scanner@2.0.0
   workflows:
     build:
       jobs:

--- a/src/jobs/scan.yml
+++ b/src/jobs/scan.yml
@@ -1,7 +1,7 @@
 description: |
   Scan Pull Requests and Commits for sensitive findings. You must set the NIGHTFALL_API_KEY as a CircleCI project environment variable to use this orb. View this orb's source and README for usage instructions.
 docker:
-  - image: 'nightfallai/nightfall_code_scanner:v1.1.4'
+  - image: 'nightfallai/nightfall_code_scanner:v2.0.0'
 parameters:
   event_before:
     default: ""


### PR DESCRIPTION
This PR involves a version bump to `nightfall_code_scanner` that features breaking changes in the schema of the config file. Refer to the config file in this PR for an example of the schema migration, or the [release notes](https://github.com/nightfallai/nightfall_code_scanner/releases/tag/v2.0.0) in the scanner repo for more information.